### PR TITLE
Added videos are always on top of the list.

### DIFF
--- a/lib/videoManagement.js
+++ b/lib/videoManagement.js
@@ -40,6 +40,7 @@ function toArray() {
 			}
 		}
 	}
+	array.sort(videoSort).reverse();
 	return array;
 }
 
@@ -54,6 +55,15 @@ function vidGetId(vid) {
 	return vid.slice(vid.indexOf("_") + 1, vid.length);
 }
 
+// Compares videos by date. Used for sorting.
+function videoSort(a, b) {
+	var timeA = 0;
+	var timeB = 0;
+	if (a != undefined) timeA = a.timeAdded;
+	if (b != undefined) timeB = b.timeAdded;
+	return timeA - timeB;
+}
+
 function Video(vid, title, time, playlistId) {
 	this.vid = vid;
 	this.title = title;
@@ -61,6 +71,8 @@ function Video(vid, title, time, playlistId) {
 	this.playlistId = playlistId; // The playlist ID of the video (based on the
 	                              // video URL) or "null" if the video is not
 	                              // part of a playlist
+	this.timeAdded = new Date().getTime(); // The timestamp when the video was
+	                                       // added to the list.
 }
 
 var siteHandlers = {};


### PR DESCRIPTION
Even if the video was already in the list.

I think this is much better than putting the new videos to the bottom of
the list (or just keeping them on the same position as they were before
if the video was already in the list).

I think the current videos are much more important than the old ones
that the user want to resume eventually in the future. Therefore I think
it is way better if we put the videos that are important to the user to
the top of the list.

Tell me what you think about this :)
